### PR TITLE
The script should be able to connect to Cloudflare with provided API key & relevant required information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
 # cf-custom-hostname
+
+## Connecting to Cloudflare
+
+To connect to Cloudflare, you need to provide an API key. You can do this by either setting an environment variable or creating a file with the API key.
+
+### Using Environment Variable
+
+Set the `CF_APIKEY` environment variable with your Cloudflare API key:
+
+```sh
+export CF_APIKEY=your_cloudflare_api_key
+```
+
+### Using a File
+
+Create a file named `.cloudflare_key` in the same directory as the script and add your Cloudflare API key to it:
+
+```sh
+echo "your_cloudflare_api_key" > .cloudflare_key
+```
+
+## Running the Script
+
+To run the script, use the following command:
+
+```sh
+python main.py
+```
+
+The script will print the current zone IDs.
+
+## Running the Unit Test
+
+To run the unit test, use the following command:
+
+```sh
+python -m unittest test_main.py
+```

--- a/main.py
+++ b/main.py
@@ -1,7 +1,33 @@
 import requests
+import os
+import json
+
+def get_api_key():
+    api_key = os.getenv("CF_APIKEY")
+    if not api_key:
+        try:
+            with open(".cloudflare_key", "r") as file:
+                api_key = file.read().strip()
+        except FileNotFoundError:
+            raise Exception("API key not found. Please set the CF_APIKEY environment variable or create a .cloudflare_key file.")
+    return api_key
+
+def get_zone_ids(api_key):
+    url = "https://api.cloudflare.com/client/v4/zones"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json"
+    }
+    response = requests.get(url, headers=headers)
+    if response.status_code != 200:
+        raise Exception(f"Failed to retrieve zone IDs: {response.status_code} {response.text}")
+    data = response.json()
+    return [zone["id"] for zone in data["result"]]
 
 def main():
-    pass
+    api_key = get_api_key()
+    zone_ids = get_zone_ids(api_key)
+    print("Zone IDs:", zone_ids)
 
 if __name__ == "__main__":
     main()

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,54 @@
+import unittest
+from unittest import mock
+import main
+
+class TestMain(unittest.TestCase):
+
+    @mock.patch('main.os.getenv')
+    @mock.patch('builtins.open', new_callable=mock.mock_open, read_data='test_api_key')
+    def test_get_api_key(self, mock_open, mock_getenv):
+        # Test when environment variable is set
+        mock_getenv.return_value = 'env_api_key'
+        self.assertEqual(main.get_api_key(), 'env_api_key')
+
+        # Test when environment variable is not set but file exists
+        mock_getenv.return_value = None
+        self.assertEqual(main.get_api_key(), 'test_api_key')
+
+        # Test when neither environment variable is set nor file exists
+        mock_open.side_effect = FileNotFoundError
+        with self.assertRaises(Exception) as context:
+            main.get_api_key()
+        self.assertTrue('API key not found' in str(context.exception))
+
+    @mock.patch('main.requests.get')
+    def test_get_zone_ids(self, mock_get):
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'result': [{'id': 'zone1'}, {'id': 'zone2'}]
+        }
+        mock_get.return_value = mock_response
+
+        api_key = 'test_api_key'
+        zone_ids = main.get_zone_ids(api_key)
+        self.assertEqual(zone_ids, ['zone1', 'zone2'])
+
+        # Test when request fails
+        mock_response.status_code = 400
+        with self.assertRaises(Exception) as context:
+            main.get_zone_ids(api_key)
+        self.assertTrue('Failed to retrieve zone IDs' in str(context.exception))
+
+    @mock.patch('main.get_zone_ids')
+    @mock.patch('main.get_api_key')
+    def test_main(self, mock_get_api_key, mock_get_zone_ids):
+        mock_get_api_key.return_value = 'test_api_key'
+        mock_get_zone_ids.return_value = ['zone1', 'zone2']
+
+        with mock.patch('builtins.print') as mock_print:
+            main.main()
+            mock_print.assert_called_with('Zone IDs:', ['zone1', 'zone2'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #3

Add functionality to connect to Cloudflare using provided API key and retrieve zone IDs.

* **main.py**
  - Import `os` and `json` modules.
  - Add `get_api_key` function to retrieve API key from environment variable or file.
  - Add `get_zone_ids` function to retrieve zone IDs from Cloudflare.
  - Update `main` function to call `get_api_key` and `get_zone_ids`, and print the zone IDs.

* **README.md**
  - Add instructions on how to provide the API key using environment variable or file.
  - Add instructions on how to run the script.
  - Add instructions on how to run the unit test.

* **test_main.py**
  - Add test cases for `get_api_key`, `get_zone_ids`, and `main` functions using `unittest` and `mock` modules.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/riveryc/cf-custom-hostname/issues/3?shareId=87bbc5b3-e8e5-42d5-9fc3-19052321a812).