### PR TITLE
Take an input as custom hostname as parameter to use public DNS to verify acme challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,13 @@ To run the unit test, use the following command:
 ```sh
 python -m unittest test_main.py
 ```
+
+## Verifying ACME Challenge
+
+To verify if the relevant ACME challenge name has been configured correctly for a custom hostname, use the following command:
+
+```sh
+python main.py --hostname your_custom_hostname
+```
+
+The script will use public DNS (8.8.8.8 or 1.1.1.1) to verify the ACME challenge name and CNAME for the provided custom hostname.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+dnspython


### PR DESCRIPTION
Fixes #7

Add functionality to verify ACME challenge and CNAME for custom hostname using public DNS.

* Add `verify_acme_challenge` function in `main.py` to verify ACME challenge and CNAME for a custom hostname using public DNS (8.8.8.8 or 1.1.1.1)
* Modify `main` function in `main.py` to accept a custom hostname as a command-line argument and call `verify_acme_challenge`
* Import `dns.resolver` module in `main.py` to perform DNS queries
* Update `README.md` with instructions on how to pass a custom hostname as a parameter and explain the verification process using public DNS and CNAME
* Add `dnspython` library to `requirements.txt`
* Add tests for `verify_acme_challenge` function and update tests for `main` function in `test_main.py` to include custom hostname parameter

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/riveryc/cf-custom-hostname/issues/7?shareId=2d816832-9b13-4d61-b454-7a24eec989e0).