### PR TITLE
Add success message and prompt after successful checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ python main.py
 
 The script will print the current zone IDs.
 
+After successful checks, the script will print "All checks successful. Ready to implement custom hostname." and prompt the user with "Do you want to proceed? (yes/no)". If the user confirms with "yes", the script proceeds to the next step. If "no", it exits.
+
 ## Running the Unit Test
 
 To run the unit test, use the following command:

--- a/main.py
+++ b/main.py
@@ -94,5 +94,11 @@ def main():
         if not is_valid_cname_target(args.hostname):
             print(f'Invalid CNAME target for {args.hostname}')
 
+    print("All checks successful. Ready to implement custom hostname.")
+    proceed = input("Do you want to proceed? (yes/no): ")
+    if proceed.lower() != 'yes':
+        print("Exiting.")
+        return
+
 if __name__ == "__main__":
     main()

--- a/test_main.py
+++ b/test_main.py
@@ -159,5 +159,19 @@ class TestMain(unittest.TestCase):
         mock_resolve.side_effect = Exception('Test error')
         self.assertFalse(main.is_valid_cname_target('cname.example.com'))
 
+    @mock.patch('builtins.input', side_effect=['yes'])
+    def test_main_proceed_yes(self, mock_input):
+        with mock.patch('builtins.print') as mock_print:
+            main.main()
+            mock_print.assert_any_call("All checks successful. Ready to implement custom hostname.")
+            mock_print.assert_any_call("Exiting.")
+
+    @mock.patch('builtins.input', side_effect=['no'])
+    def test_main_proceed_no(self, mock_input):
+        with mock.patch('builtins.print') as mock_print:
+            main.main()
+            mock_print.assert_any_call("All checks successful. Ready to implement custom hostname.")
+            mock_print.assert_any_call("Exiting.")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #15

Add success message and user prompt after successful checks in `main.py`.

* **main.py**
  - Print "All checks successful. Ready to implement custom hostname." after successful checks.
  - Prompt the user with "Do you want to proceed? (yes/no)" and wait for confirmation.
  - Exit if the user responds with "no".

* **README.md**
  - Update the "Running the Script" section to include information about the success message and user prompt.

* **test_main.py**
  - Add tests to verify the success message and user prompt functionality.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/riveryc/cf-custom-hostname/issues/15?shareId=6abdde8b-9329-42e2-9dc0-4e7cdceec60e).