### PR TITLE
List all domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To run the script, use the following command:
 python main.py
 ```
 
-The script will print the current zone IDs.
+The script will print the current zone IDs and domains.
 
 After successful checks, the script will print "All checks successful. Ready to implement custom hostname." and prompt the user with "Do you want to proceed? (yes/no)". If the user confirms with "yes", the script proceeds to the next step. If "no", it exits.
 


### PR DESCRIPTION
Fixes #17

Add functionality to list all domains associated with zone IDs.

* **main.py**
  - Add `get_domains` function to fetch and list all domains associated with the zone IDs.
  - Call `get_domains` function in the `main` function to list all domains.

* **README.md**
  - Update instructions to include listing all domains.

* **test_main.py**
  - Add tests for the `get_domains` function.
  - Update `test_main` to include testing for domain listing.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/riveryc/cf-custom-hostname/issues/17?shareId=64c67292-1abe-4708-8762-4673f4299b7c).